### PR TITLE
feat: add guid column to checkout coutner entity and add guid and aliastype to qr string

### DIFF
--- a/packages/acquirer-backend/src/entity/CheckoutCounterEntity.ts
+++ b/packages/acquirer-backend/src/entity/CheckoutCounterEntity.ts
@@ -14,6 +14,9 @@ export class CheckoutCounterEntity {
   @Column({ nullable: true, length: 255 })
     description!: string
 
+  @Column({ nullable: true, length: 512 })
+    guid!: string
+
   @Column({ nullable: true, length: 255 })
     notification_number!: string
 

--- a/packages/acquirer-backend/src/services/generateQRImage.ts
+++ b/packages/acquirer-backend/src/services/generateQRImage.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import { crc16ccitt } from 'crc'
 
 export const getEMVQRCodeText = (
+  guid: string,
   checkoutCounterAliasValue: string,
   merchantCategoryCode: string,
   transactionCurrency: string,
@@ -22,8 +23,11 @@ export const getEMVQRCodeText = (
   emvQRCodeText += addDataObject('01', '12')
 
   // Merchant Additional Info
-  const aliasObj = addDataObject('01', checkoutCounterAliasValue)
-  emvQRCodeText += addDataObject('28', aliasObj)
+  const guidObj = addDataObject('00', guid)
+  const aliasType = addDataObject('01', 'ALIAS')
+  const aliasObj = addDataObject('02', checkoutCounterAliasValue)
+
+  emvQRCodeText += addDataObject('28', guidObj + aliasType + aliasObj)
 
   emvQRCodeText += addDataObject('52', merchantCategoryCode)
   emvQRCodeText += addDataObject('53', transactionCurrency)


### PR DESCRIPTION
sample qr string with guid and aliastype

`00020101021228590036e2ca833d-e3f4-4e18-be18-c41f1d2f0b900105ALIAS02060000195205141105303DJF5802AR5902TT6019Las Matas de Farfan630446EE`

QR breakdown
```
00 02 01
01 02 12
28 59
  00 36 e2ca833d-e3f4-4e18-be18-c41f1d2f0b90 // GUID
  01 05 ALIAS            // Alias Type
  02 06 000019        // Alias Value
52 05 14110            // Merchant Category
53 03 DJF                 // Currency
58 02 AR                  // Country Code
59 02 TT                  // Merchant DBA Name
60 19 Las Matas de Farfan // City
63 04 46EE             // CRC
```