### PR TITLE
feat: remove DFSP Super Admin Role

### DIFF
--- a/packages/acquirer-backend/__tests__/e2e/PutRoleUpdatePermissions.tests.ts
+++ b/packages/acquirer-backend/__tests__/e2e/PutRoleUpdatePermissions.tests.ts
@@ -29,7 +29,7 @@ export function testPutRoleUpdatePermissions (app: Application): void {
     hubUserRole.permissions.push(editRolePermission)
     await AppDataSource.manager.save(hubUserRole)
 
-    const role = await AppDataSource.manager.findOneOrFail(PortalRoleEntity, { where: { name: 'DFSP Super Admin' } })
+    const role = await AppDataSource.manager.findOneOrFail(PortalRoleEntity, { where: { name: 'DFSP Admin' } })
     roleId = role.id
   })
 

--- a/packages/acquirer-backend/__tests__/integration/seedDefaultUsers.tests.ts
+++ b/packages/acquirer-backend/__tests__/integration/seedDefaultUsers.tests.ts
@@ -31,7 +31,7 @@ export function seedDefaultUsersTests (): void {
     await AppDataSource.manager.delete(PortalRoleEntity, { name: DefaultHubUsers[0].role }) // Deleting role to ensure it does not exist
 
     // Act & Assert
-    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrowError(new Error(
+    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrow(new Error(
       `Role '${DefaultHubUsers[0].role}' not found for seeding with '${DefaultHubUsers[0].email}'.`
     ))
 
@@ -46,7 +46,7 @@ export function seedDefaultUsersTests (): void {
     await AppDataSource.manager.clear(PortalRoleEntity) // Clearing roles to ensure none exists
 
     // Act & Assert
-    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrowError(new Error(
+    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrow(new Error(
       `Role '${DefaultDFSPUsers[0].role}' not found for seeding with '${DefaultDFSPUsers[0].email}'.`
     ))
 
@@ -60,7 +60,7 @@ export function seedDefaultUsersTests (): void {
     await seedDefaultRoles(AppDataSource)
 
     // Act & Assert
-    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrowError(
+    await expect(seedAllDefaultUsers(AppDataSource)).rejects.toThrow(
       new Error(`DFSP '${DefaultDFSPUsers[0].dfsp_name}' not found for seeding with '${DefaultDFSPUsers[0].email}'.`)
     )
 

--- a/packages/acquirer-backend/src/database/defaultRoles.ts
+++ b/packages/acquirer-backend/src/database/defaultRoles.ts
@@ -15,7 +15,7 @@ export const DefaultRoles = [
     permissions: [
       PermissionsEnum.CREATE_PORTAL_USERS,
       PermissionsEnum.CREATE_HUB_ADMIN,
-      PermissionsEnum.CREATE_DFSP_SUPER_AMDIN,
+      PermissionsEnum.CREATE_DFSP_ADMIN,
 
       PermissionsEnum.VIEW_DFSPS,
       PermissionsEnum.CREATE_DFSPS,
@@ -30,31 +30,6 @@ export const DefaultRoles = [
       PermissionsEnum.VIEW_AUDIT_LOGS,
 
       PermissionsEnum.EDIT_SERVER_LOG_LEVEL
-    ]
-  },
-  {
-    name: 'DFSP Super Admin',
-    description: 'DFSP Super Admin Role',
-    permissions: [
-      PermissionsEnum.CREATE_PORTAL_USERS,
-      PermissionsEnum.CREATE_DFSP_ADMIN,
-      PermissionsEnum.CREATE_DFSP_OPERATOR,
-      PermissionsEnum.CREATE_DFSP_AUDITOR,
-
-      PermissionsEnum.APPROVE_MERCHANTS,
-      PermissionsEnum.REJECT_MERCHANTS,
-      PermissionsEnum.REVERT_MERCHANTS,
-
-      PermissionsEnum.VIEW_MERCHANTS,
-      PermissionsEnum.CREATE_MERCHANTS,
-      PermissionsEnum.EDIT_MERCHANTS,
-      // PermissionsEnum.DELETE_MERCHANTS,
-
-      PermissionsEnum.VIEW_PORTAL_USERS,
-
-      PermissionsEnum.EXPORT_MERCHANTS,
-
-      PermissionsEnum.VIEW_AUDIT_LOGS
     ]
   },
   {

--- a/packages/acquirer-backend/src/database/defaultUsers.ts
+++ b/packages/acquirer-backend/src/database/defaultUsers.ts
@@ -7,24 +7,9 @@ export const DefaultHubUsers = [
     role: 'Hub Admin'
   }
 ]
+
 export const DefaultDFSPUsers = [
   // Green Bank
-  {
-    email: 'greenbanksuperadmin1@email.com',
-    name: 'Green Bank Super Admin 1',
-    password: 'password',
-    phone_number: '0000000',
-    role: 'DFSP Super Admin',
-    dfsp_name: 'Green Bank'
-  },
-  {
-    email: 'greenbanksuperadmin2@email.com',
-    name: 'Green Bank Super Admin 2',
-    password: 'password',
-    phone_number: '0000000',
-    role: 'DFSP Super Admin',
-    dfsp_name: 'Green Bank'
-  },
   {
     email: 'greenbankadmin1@email.com',
     name: 'Green Bank Admin 1',
@@ -44,18 +29,18 @@ export const DefaultDFSPUsers = [
 
   // DFSP 1
   {
-    email: 'd1superadmin1@email.com',
-    name: 'DFSP 1 Super Admin 1',
-    password: 'password',
-    phone_number: '0000000',
-    role: 'DFSP Super Admin',
-    dfsp_name: 'DFSP 1'
-  },
-  {
     email: 'd1admin1@email.com',
     name: 'DFSP 1 Admin 1',
     password: 'password',
     phone_number: '1111111',
+    role: 'DFSP Admin',
+    dfsp_name: 'DFSP 1'
+  },
+  {
+    email: 'd1admin2@email.com',
+    name: 'DFSP 1 Admin 2',
+    password: 'password',
+    phone_number: '2222222',
     role: 'DFSP Admin',
     dfsp_name: 'DFSP 1'
   },
@@ -86,11 +71,11 @@ export const DefaultDFSPUsers = [
 
   // DFSP 2
   {
-    email: 'd2superadmin1@email.com',
-    name: 'DFSP 2 Super Admin 2',
+    email: 'd2admin2@email.com',
+    name: 'DFSP 2 Admin 2',
     password: 'password',
-    phone_number: '0000000',
-    role: 'DFSP Super Admin',
+    phone_number: '2222222',
+    role: 'DFSP Admin',
     dfsp_name: 'DFSP 2'
   },
   {
@@ -128,18 +113,18 @@ export const DefaultDFSPUsers = [
 
   // DFSP 3
   {
-    email: 'd3superadmin1@email.com',
-    name: 'DFSP 3 Super Admin 1',
-    password: 'password',
-    phone_number: '0000000',
-    role: 'DFSP Super Admin',
-    dfsp_name: 'DFSP 3'
-  },
-  {
     email: 'd3admin1@email.com',
     name: 'DFSP 3 Admin 1',
     password: 'password',
     phone_number: '1111111',
+    role: 'DFSP Admin',
+    dfsp_name: 'DFSP 3'
+  },
+  {
+    email: 'd3admin2@email.com',
+    name: 'DFSP 3 Admin 2',
+    password: 'password',
+    phone_number: '2222222',
     role: 'DFSP Admin',
     dfsp_name: 'DFSP 3'
   },

--- a/packages/acquirer-backend/src/middleware/checkUserCreationPermission.ts
+++ b/packages/acquirer-backend/src/middleware/checkUserCreationPermission.ts
@@ -17,7 +17,6 @@ export function checkUserCreationPermission () {
       'Hub Super Admin': PermissionsEnum.CREATE_HUB_SUPER_ADMIN,
       'Hub Admin': PermissionsEnum.CREATE_HUB_ADMIN,
 
-      'DFSP Super Admin': PermissionsEnum.CREATE_DFSP_SUPER_AMDIN,
       'DFSP Admin': PermissionsEnum.CREATE_DFSP_ADMIN,
       'DFSP Operator': PermissionsEnum.CREATE_DFSP_OPERATOR,
       'DFSP Auditor': PermissionsEnum.CREATE_DFSP_AUDITOR

--- a/packages/acquirer-backend/src/types/permissions.ts
+++ b/packages/acquirer-backend/src/types/permissions.ts
@@ -4,7 +4,6 @@ export enum PermissionsEnum {
   CREATE_HUB_SUPER_ADMIN = 'Create Hub Super Admin',
   CREATE_HUB_ADMIN = 'Create Hub Admin',
 
-  CREATE_DFSP_SUPER_AMDIN = 'Create DFSP Super Admin',
   CREATE_DFSP_ADMIN = 'Create DFSP Admin',
   CREATE_DFSP_OPERATOR = 'Create DFSP Operator',
   CREATE_DFSP_AUDITOR = 'Create DFSP Auditor',

--- a/packages/acquirer-frontend/src/contexts/NavItemsContext.test.tsx
+++ b/packages/acquirer-frontend/src/contexts/NavItemsContext.test.tsx
@@ -107,9 +107,9 @@ describe('NavItemsContext', () => {
   it('should have access to all routes when the user is not operator or auditor', () => {
     mockUserProfile.mockReturnValue({
       id: 5,
-      name: 'DFSP 1 Super Admin 1',
+      name: 'DFSP 1 Admin 1',
       role: {
-        name: 'DFSP Super Admin',
+        name: 'DFSP Admin',
       },
     })
     Storage.prototype.getItem = () => 'token'

--- a/packages/acquirer-frontend/src/lib/axiosInstance.test.ts
+++ b/packages/acquirer-frontend/src/lib/axiosInstance.test.ts
@@ -10,7 +10,7 @@ describe('Axios Interceptor', () => {
     const mock = new MockAdapter(instance)
     mock.onGet('/users/profile').reply(200, {
       id: 5,
-      name: 'DFSP 1 Super Admin 1',
+      name: 'DFSP 1 Admin 1',
     })
 
     const response = await instance.get('/users/profile')

--- a/packages/acquirer-frontend/src/pages/AddNewUser/AddNewUser.test.tsx
+++ b/packages/acquirer-frontend/src/pages/AddNewUser/AddNewUser.test.tsx
@@ -14,10 +14,9 @@ const hoistedValues = vi.hoisted(() => ({
         'Create Roles',
         'View Roles',
         'Edit Roles',
-        'Assignable Admin Roles',
-        'Assignable Operator Roles',
-        'Assignable Auditor Roles',
         'Create Portal Users',
+        'Create Hub Admin',
+        'Create DFSP Admin',
         'View Portal Users',
         'Edit Portal Users',
         'Delete Portal Users',
@@ -30,12 +29,10 @@ const hoistedValues = vi.hoisted(() => ({
       ],
     },
     {
-      description: 'DFSP Super Admin',
+      description: 'DFSP Admin',
       id: 2,
-      name: 'DFSP Super Admin',
+      name: 'DFSP Admin',
       permissions: [
-        'Access Create Merchant Form',
-        'Access Edit Merchant Form',
         'Approve Merchants',
         'Reject Merchants',
         'Revert Merchants',
@@ -47,37 +44,9 @@ const hoistedValues = vi.hoisted(() => ({
         'View Reverted Table',
         'Create Roles',
         'View Roles',
-        'Assignable Admin Roles',
-        'Assignable Operator Roles',
-        'Assignable Auditor Roles',
         'Create Portal Users',
-        'View Portal Users',
-        'Edit Portal Users',
-        'Delete Portal Users',
-        'Export Merchants',
-        'View Audit Logs',
-      ],
-    },
-    {
-      description: 'DFSP Admin',
-      id: 3,
-      name: 'DFSP Admin',
-      permissions: [
-        'Access Create Merchant Form',
-        'Access Edit Merchant Form',
-        'Approve Merchants',
-        'Reject Merchants',
-        'Revert Merchants',
-        'View Merchants',
-        'Create Merchants',
-        'Edit Merchants',
-        'Delete Merchants',
-        'View Pending Table',
-        'View Reverted Table',
-        'View Roles',
-        'Assignable Operator Roles',
-        'Assignable Auditor Roles',
-        'Create Portal Users',
+        'Create DFSP Operator',
+        'Create DFSP Auditor',
         'View Portal Users',
         'Edit Portal Users',
         'Delete Portal Users',
@@ -144,34 +113,13 @@ describe('AddNewUser', () => {
     vi.restoreAllMocks()
   })
 
-  it('should show admin, operator and auditor roles when user is super admin', () => {
-    mockUserProfile.mockReturnValue({
-      isSuccess: true,
-      data: {
-        id: 5,
-        name: 'DFSP 1 Super Admin 1',
-        role: hoistedValues.roles[1],
-      },
-    })
-
-    render(
-      <TestWrapper>
-        <AddNewUser />
-      </TestWrapper>
-    )
-
-    expect(screen.getByText('DFSP Admin')).toBeInTheDocument()
-    expect(screen.getByText('DFSP Operator')).toBeInTheDocument()
-    expect(screen.getByText('DFSP Auditor')).toBeInTheDocument()
-  })
-
   it('should show operator and auditor roles when user is admin', () => {
     mockUserProfile.mockReturnValue({
       isSuccess: true,
       data: {
         id: 6,
         name: 'DFSP 1 Admin 1',
-        role: hoistedValues.roles[2],
+        role: hoistedValues.roles[1],
       },
     })
 
@@ -191,7 +139,7 @@ describe('AddNewUser', () => {
       isSuccess: true,
       data: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
         role: hoistedValues.roles[1],
       },
     })
@@ -210,11 +158,10 @@ describe('AddNewUser', () => {
 
     fireEvent.change(nameInput, { target: { value: 'John' } })
     fireEvent.change(emailInput, { target: { value: 'john@gmail.com' } })
-    fireEvent.change(roleInput, { target: { value: 'DFSP Admin' } })
+    fireEvent.change(roleInput, { target: { value: 'DFSP Operator' } })
     fireEvent.click(submitButton)
 
     await waitFor(() => Promise.resolve)
-
     expect(mutateAsyncSpy).toHaveBeenCalled()
   })
 
@@ -223,7 +170,7 @@ describe('AddNewUser', () => {
       isSuccess: true,
       data: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
         role: hoistedValues.roles[1],
       },
     })
@@ -241,7 +188,7 @@ describe('AddNewUser', () => {
 
     fireEvent.change(nameInput, { target: { value: 'John' } })
     fireEvent.change(emailInput, { target: { value: 'john@gmail.com' } })
-    fireEvent.change(roleInput, { target: { value: 'DFSP Admin' } })
+    fireEvent.change(roleInput, { target: { value: 'DFSP Operator' } })
     fireEvent.click(cancelButton)
 
     expect(nameInput.value).toEqual('')

--- a/packages/acquirer-frontend/src/pages/AddNewUser/AddNewUser.tsx
+++ b/packages/acquirer-frontend/src/pages/AddNewUser/AddNewUser.tsx
@@ -26,17 +26,17 @@ const AddNewUser = () => {
   let roleOptions
   if (roles.isSuccess && userProfile.isSuccess) {
     const createAccesses: Role[] = []
-    if (userProfile.data.role.permissions.includes('Assignable Admin Roles')) {
+    if (userProfile.data.role.permissions.includes('Create DFSP Admin')) {
       createAccesses.push(roles.data.data.filter(role => role.name === 'DFSP Admin')[0])
     }
 
-    if (userProfile.data.role.permissions.includes('Assignable Operator Roles')) {
+    if (userProfile.data.role.permissions.includes('Create DFSP Operator')) {
       createAccesses.push(
         roles.data.data.filter(role => role.name === 'DFSP Operator')[0]
       )
     }
 
-    if (userProfile.data.role.permissions.includes('Assignable Auditor Roles')) {
+    if (userProfile.data.role.permissions.includes('Create DFSP Auditor')) {
       createAccesses.push(roles.data.data.filter(role => role.name === 'DFSP Auditor')[0])
     }
 

--- a/packages/acquirer-frontend/src/pages/AliasGeneratedMerchantRecords/AliasGeneratedMerchantRecords.test.tsx
+++ b/packages/acquirer-frontend/src/pages/AliasGeneratedMerchantRecords/AliasGeneratedMerchantRecords.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Approved',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 

--- a/packages/acquirer-frontend/src/pages/AllMerchantRecords/AllMerchantRecords.test.tsx
+++ b/packages/acquirer-frontend/src/pages/AllMerchantRecords/AllMerchantRecords.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Pending',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 

--- a/packages/acquirer-frontend/src/pages/AuditLog/AuditLog.test.tsx
+++ b/packages/acquirer-frontend/src/pages/AuditLog/AuditLog.test.tsx
@@ -14,13 +14,13 @@ const hoistedValues = vi.hoisted(() => ({
       eventDescription: 'Get a list of users',
       newValue: '{}',
       oldValue: '{}',
-      portalUserName: 'DFSP 1 Super Admin 1',
+      portalUserName: 'DFSP 1 Admin 1',
       transactionStatus: 'Success',
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 
@@ -148,7 +148,7 @@ describe('AuditLog', () => {
     const clearFilterButton = screen.getByText('Clear Filter')
 
     fireEvent.change(actionTypeInput, { target: { value: 'Access' } })
-    fireEvent.change(portalUserNameInput, { target: { value: 'DFSP 1 Super Admin 1' } })
+    fireEvent.change(portalUserNameInput, { target: { value: 'DFSP 1 Admin 1' } })
     fireEvent.click(clearFilterButton)
 
     expect(actionTypeInput.value).toEqual('')
@@ -177,7 +177,7 @@ describe('AuditLog', () => {
     const searchButton = screen.getByText('Search')
 
     fireEvent.change(actionTypeInput, { target: { value: 'Access' } })
-    fireEvent.change(portalUserNameInput, { target: { value: 'DFSP 1 Super Admin 1' } })
+    fireEvent.change(portalUserNameInput, { target: { value: 'DFSP 1 Admin 1' } })
     fireEvent.click(searchButton)
 
     await waitFor(() => Promise.resolve())

--- a/packages/acquirer-frontend/src/pages/DraftApplications/DraftApplications.test.tsx
+++ b/packages/acquirer-frontend/src/pages/DraftApplications/DraftApplications.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Draft',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 

--- a/packages/acquirer-frontend/src/pages/PendingMerchantRecords/PendingMerchantRecords.test.tsx
+++ b/packages/acquirer-frontend/src/pages/PendingMerchantRecords/PendingMerchantRecords.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Pending',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 
@@ -75,7 +75,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should render form skeleton when users data is loading', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: null, isLoading: true })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -93,7 +93,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should render filter form when users data is successfully loaded', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -111,7 +111,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should render table skeleton when pending merchants data is loading', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: null,
@@ -129,7 +129,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should render table content when pending merchants data is successfully loaded', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -151,7 +151,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should reset the filter form values when "Clear Filter" button is clicked', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -195,7 +195,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should call "pendingMerchants.refetch" function when the filter form is submitted', async () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -220,7 +220,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should disable row select checkbox when the logged in user is the maker', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 5, name: 'DFSP 1 Super Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 5, name: 'DFSP 1 Admin 1' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -242,7 +242,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should call "exportMerchants.mutateAsync" function when "Export" button is clicked', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -264,7 +264,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should call "rejectMerchants.mutateAsync" function when "Reject" button is clicked', async () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -300,7 +300,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should call "approveMerchants.mutateAsync" function when "Approve" button is clicked', async () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -331,7 +331,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should call "revertMerchants.mutateAsync" function when "Revert" button is clicked', async () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },
@@ -367,7 +367,7 @@ describe('PendingMerchantRecords', () => {
   })
 
   it('should render merchant info modal when "View Details" button is clicked', () => {
-    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 1' } })
+    mockUserProfile.mockReturnValue({ data: { id: 6, name: 'DFSP 1 Admin 2' } })
     mockUsers.mockReturnValue({ data: hoistedValues.users, isLoading: false })
     mockPendingMerchants.mockReturnValue({
       data: { data: hoistedValues.pendingMerchants, totalPages: 1 },

--- a/packages/acquirer-frontend/src/pages/RejectedMerchantRecords/RejectedMerchantRecords.test.tsx
+++ b/packages/acquirer-frontend/src/pages/RejectedMerchantRecords/RejectedMerchantRecords.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Rejected',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 

--- a/packages/acquirer-frontend/src/pages/RevertedMerchantRecords/RevertedMerchantRecords.test.tsx
+++ b/packages/acquirer-frontend/src/pages/RevertedMerchantRecords/RevertedMerchantRecords.test.tsx
@@ -19,13 +19,13 @@ const hoistedValues = vi.hoisted(() => ({
       registrationStatus: 'Reverted',
       maker: {
         id: 5,
-        name: 'DFSP 1 Super Admin 1',
+        name: 'DFSP 1 Admin 1',
       },
     },
   ],
   users: [
-    { id: 5, name: 'DFSP 1 Super Admin 1' },
-    { id: 6, name: 'DFSP 1 Admin 1' },
+    { id: 5, name: 'DFSP 1 Admin 1' },
+    { id: 6, name: 'DFSP 1 Admin 2' },
   ],
 }))
 

--- a/packages/acquirer-frontend/src/pages/UserManagement/UserManagement.test.tsx
+++ b/packages/acquirer-frontend/src/pages/UserManagement/UserManagement.test.tsx
@@ -8,13 +8,13 @@ const hoistedValues = vi.hoisted(() => ({
   users: [
     {
       id: 5,
-      name: 'DFSP 1 Super Admin 1',
-      email: 'd1superadmin1@email.com',
-      phone_number: '0000000',
+      name: 'DFSP 1 Admin 1',
+      email: 'd1admin1@email.com',
+      phone_number: '1111111',
       role: {
         id: 2,
-        name: 'DFSP Super Admin',
-        description: 'DFSP Super Admin',
+        name: 'DFSP Admin',
+        description: 'DFSP Admin',
       },
       user_type: 'DFSP',
       status: 'Active',


### PR DESCRIPTION
Frontend: `Assignable ....`  permissions are renamed to `Create DFSP Admin/Operator/Auditor`
