### PR TITLE
fix: newly created user was locked if refuse to immediately reset password after email verification

### DIFF
--- a/packages/acquirer-backend/__tests__/e2e/VerifyUser.tests.ts
+++ b/packages/acquirer-backend/__tests__/e2e/VerifyUser.tests.ts
@@ -80,31 +80,6 @@ export function testVerifyUser (app: Application): void {
     expect(response.body.message).toEqual('Token not found')
   })
 
-  it('should return 400 when token is already used', async () => {
-    // Arrange
-    const verifiedUser = AppDataSource.manager.create(PortalUserEntity)
-    verifiedUser.name = 'New Unverification User'
-    verifiedUser.email = 'new-unverification-user@email.com'
-    verifiedUser.user_type = PortalUserType.HUB
-    verifiedUser.status = PortalUserStatus.RESETPASSWORD
-    await AppDataSource.manager.save(verifiedUser)
-
-    const usedToken = jwt.sign(
-      { id: verifiedUser.id, email: verifiedUser.email },
-      JWT_SECRET, { expiresIn: '1y' })
-
-    await AppDataSource.manager.save(EmailVerificationTokenEntity, {
-      user: verifiedUser,
-      token: usedToken,
-      email: verifiedUser.email,
-      is_used: true
-    })
-
-    const response = await request(app).get(`/api/v1/users/verify?token=${usedToken}`)
-    expect(response.status).toBe(400)
-    expect(response.body.message).toEqual('Token already used')
-  })
-
   it('should return 404 when user does not exist', async () => {
     const nonExistEmailToken = jwt.sign(
       { id: unVerifyUser.id, email: 'random-nonexistent-user@email.com' },

--- a/packages/acquirer-backend/src/routes/userControllers/addUserByAdmin.ts
+++ b/packages/acquirer-backend/src/routes/userControllers/addUserByAdmin.ts
@@ -24,9 +24,6 @@ const AddUserSchema = z.object({
 
 const JWT_SECRET = readEnv('JWT_SECRET', '') as string
 
-const JWT_EXPIRES_IN = readEnv('JWT_EXPIRES_IN', '1d') as string
-const JWT_EXPIRES_IN_MS = ms(JWT_EXPIRES_IN)
-
 /**
  * @openapi
  * /users/add:
@@ -185,12 +182,12 @@ export async function addUser (req: AuthRequest, res: Response) {
       )
 
       // Generate Token using jwt
-      const token = jwt.sign({ id: newUser.id, email: newUser.email }, JWT_SECRET, { expiresIn: '1y' })
+      const token = jwt.sign({ id: newUser.id, email: newUser.email }, JWT_SECRET, { expiresIn: '1h' })
 
       const jwtTokenObj = transactionalEntityManager.create(JwtTokenEntity, {
         token,
         user: newUser,
-        expires_at: new Date(Date.now() + JWT_EXPIRES_IN_MS),
+        expires_at: new Date(Date.now() + ms('1h')),
         last_used: new Date()
       })
 

--- a/packages/acquirer-backend/src/routes/userControllers/verifyUser.ts
+++ b/packages/acquirer-backend/src/routes/userControllers/verifyUser.ts
@@ -61,10 +61,6 @@ export async function verifyUserEmail (req: Request, res: Response) {
     return res.status(404).send({ message: 'Token not found' })
   }
 
-  if (emailVerificationToken.is_used) {
-    return res.status(400).send({ message: 'Token already used' })
-  }
-
   const user = await PortalUserRepository.findOne({
     where: { email: emailVerificationToken.email },
     relations: ['created_by']


### PR DESCRIPTION
removed `Token already used` check together with test case.
instead provide user with temporary (expire in 1hr) auth token to reset password.. 